### PR TITLE
Set Target to Min/Max value when progress is lower

### DIFF
--- a/Xamanimation/Behaviors/AnimateProgressDouble.cs
+++ b/Xamanimation/Behaviors/AnimateProgressDouble.cs
@@ -36,11 +36,15 @@
 
         protected override void OnUpdate()
         {
-            if (Progress < Minimum)
+            if (Progress < Minimum) {
+                Target.SetValue(TargetProperty, From * MultiplyValue);
                 return;
+            }
 
-            if (Progress >= Maximum)
+            if (Progress >= Maximum) {
+                Target.SetValue(TargetProperty, To * MultiplyValue);
                 return;
+            }
 
             //Formula Used
             //Y = ((X - X1)*(Y2 - Y1) / (X2 - X1)) + Y1

--- a/Xamanimation/Behaviors/AnimateProgressInt.cs
+++ b/Xamanimation/Behaviors/AnimateProgressInt.cs
@@ -26,11 +26,15 @@
 
         protected override void OnUpdate()
         {
-            if (Progress < Minimum)
+            if (Progress < Minimum) {
+                Target.SetValue(TargetProperty, From);
                 return;
+            }
 
-            if (Progress >= Maximum)
+            if (Progress >= Maximum) {
+                Target.SetValue(TargetProperty, To);
                 return;
+            }
 
             int? value = (int)(((Progress - Minimum) * (To - From) / (Maximum - Minimum)) + From);
 


### PR DESCRIPTION
When scrolling to fast on iPhone the objects not ready go all the way to max/min value.

So if progress < min we can set the target value to from and progress >= max we set the target value to to.

This solves the problem and makes the animation run smoothly.

